### PR TITLE
[FIX] residual in journal dashboard

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -224,7 +224,7 @@ class account_journal(models.Model):
         data as its first element, and the arguments dictionary to use to run
         it as its second.
         """
-        return ("""SELECT state, amount_total, currency_id AS currency
+        return ("""SELECT state, residual_company_signed as amount_total, currency_id AS currency
                   FROM account_invoice
                   WHERE journal_id = %(journal_id)s AND state = 'open';""", {'journal_id':self.id})
 


### PR DESCRIPTION
Before this change, the amount displayed in the dashboard is the sum of the total amount of unpaid invoices.

This means if you have some partially paid invoices, the display amount is not the sum of expected payments.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
